### PR TITLE
💚 fix pages build error with auth hook

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+use-node-version=20.10.0

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,6 +1,11 @@
+import { building } from "$app/environment";
 import { redirect, type Handle } from "@sveltejs/kit";
 
 export const handle: Handle = async ({ event, resolve }) => {
+  if (building) {
+    return resolve(event);
+  }
+
   const sessionId = event.cookies.get("sessionId");
 
   if (!sessionId && event.url.pathname !== "/sign-in") {


### PR DESCRIPTION
## 📝 Description

- add `use-node-version=20.10.0` for pnpm to pin the node version used by pnpm
- fix failing builds when an auth hook is defined in `hook.server.ts`

## ✏️ Additional Information

References:
- [pnpm/pnpm#5266](https://github.com/pnpm/pnpm/issues/5266#issuecomment-1230366384)
- [sveltejs/kit#9386](https://github.com/sveltejs/kit/issues/9386#issuecomment-1521102567)